### PR TITLE
chore: Make sure the META.json gets the data during release

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -37,12 +37,16 @@ WriteMakefile(
     AUTHOR         => 'Mike Shipper <AKALINUX@CPAN.ORG>',
     META_MERGE=>{
       "meta-spec" => { version => 2 },
-      repository => {
+      resources => {
+          repository => {
                 type => 'git',
                 url => 'https://github.com/akalinux/xml-sig-oo.git',
                 web => 'https://github.com/akalinux/xml-sig-oo',
-
-      },
+          },
+          bugtracker => {
+             web => 'https://github.com/akalinux/xml-sig-oo/issues'
+          },
+      }
     },
     "TEST_REQUIRES" => {
           "Test::More" => "0.88",


### PR DESCRIPTION
META.json currently does not include the data from META_MERGE and this MetaCPAN does not link to the repository: 
https://metacpan.org/dist/XML-Sig-OO

This change fixes that for the next release.
